### PR TITLE
Add automation to register on Sovrin StagingNet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ Temporary Items
 ## Project specific
 **/realm-export-docker.json
 **/.env
+docker/taa_payload.json

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -114,7 +114,7 @@ services:
     environment:
       ACAPY_LABEL: ${AGENT_NAME}
       ACAPY_ENDPOINT: ${AGENT_ENDPOINT}
-      ACAPY_GENESIS_URL: ${LEDGER_URL}/genesis
+      ACAPY_GENESIS_URL: ${LEDGER_URL}
       ACAPY_WALLET_NAME: ${AGENT_WALLET_NAME}
       ACAPY_WALLET_TYPE: "indy"
       ACAPY_WALLET_KEY: ${AGENT_WALLET_ENCRYPTION_KEY}
@@ -122,12 +122,13 @@ services:
       ACAPY_WALLET_STORAGE_TYPE: ${AGENT_WALLET_STORAGE_TYPE}
       ACAPY_AUTO_PROVISION: "true"
       ACAPY_WEBHOOK_URL: ${AGENT_WEBHOOK_URL}
-      ACAPY_LOG_LEVEL: ${AGENT_LOG_LEVEL}
+      ACAPY_LOG_LEVEL: ${LOG_LEVEL}
       ACAPY_AUTO_ACCEPT_INVITES: "true"
       ACAPY_AUTO_ACCEPT_REQUESTS: "true"
       ACAPY_AUTO_PING_CONNECTION: "true"
       ACAPY_AUTO_RESPOND_MESSAGES: "true"
       ACAPY_TAILS_SERVER_BASE_URL: ${TAILS_SERVER_URL}
+      ACAPY_READ_ONLY_LEDGER: ${AGENT_READ_ONLY_MODE}
       AGENT_HTTP_IN_PORT: ${AGENT_HTTP_IN_PORT}
       AGENT_WS_IN_PORT: ${AGENT_WS_IN_PORT}
       AGENT_ADMIN_PORT: ${AGENT_ADMIN_PORT}
@@ -146,9 +147,7 @@ services:
     entrypoint: /bin/bash
     command: [
         "-c",
-        "curl -d '{\"seed\":\"${AGENT_WALLET_SEED}\", \"role\":\"ENDORSER\", \"alias\":\"${AGENT_WALLET_NAME}\"}' -X POST ${LEDGER_URL}/register; \
-        sleep 5; \
-        aca-py start \
+        "aca-py start \
         --inbound-transport http '0.0.0.0' ${AGENT_HTTP_IN_PORT} \
         --inbound-transport ws '0.0.0.0' ${AGENT_WS_IN_PORT} \
         --outbound-transport ws \

--- a/docker/manage
+++ b/docker/manage
@@ -228,9 +228,11 @@ acceptTAA() {
 }
 
 provisionAgent(){
-    AGENT_WALLET_SEED=$(generateSeed dts-vc-issuer-demo)
-    echo "Generated AGENT_WALLET_SEED=${AGENT_WALLET_SEED}"
-    echo "AGENT_WALLET_SEED=${AGENT_WALLET_SEED}" > .env
+    if [[ ! -f ".env" ]]; then
+      AGENT_WALLET_SEED=$(generateSeed dts-vc-issuer-demo)
+      echo "Generated AGENT_WALLET_SEED=${AGENT_WALLET_SEED}"
+      echo "AGENT_WALLET_SEED=${AGENT_WALLET_SEED}" > .env
+    fi
 
     echo -e "\nStarting agent in read-only mode...\n"
     export AGENT_READ_ONLY_MODE="true"
@@ -474,9 +476,7 @@ case "${COMMAND}" in
     isJQInstalled
     isCurlInstalled
 
-    if [[ ! -f ".env" ]]; then
-      provisionAgent
-    fi
+    provisionAgent
   ;;
   start|start|up)
     isJQInstalled

--- a/docker/manage
+++ b/docker/manage
@@ -143,7 +143,7 @@ pingAgent(){
   port=${1}
 
   # ping agent using a backchannel-exposed api
-  rtnCd=$(curl -s --write-out '%{http_code}' --output /dev/null http://localhost:${port}/api/doc)
+  rtnCd=$(${CURL_EXE} -s --write-out '%{http_code}' --output /dev/null http://localhost:${port}/api/doc)
   if (( ${rtnCd} == 200 )); then
     return 0
   else
@@ -155,19 +155,16 @@ waitForAgent(){
   (
     # Wait for agent to start ...
     local startTime=${SECONDS}
-    rtnCd=0
     printf "Waiting for agent to start"
     while ! pingAgent ${@}; do
       printf "."
       local duration=$(($SECONDS - $startTime))
       if (( ${duration} >= ${AGENT_TIMEOUT} )); then
         echoRed "\nThe agent failed to start within ${duration} seconds.\n"
-        rtnCd=1
-        break
+        exit 1
       fi
       sleep 1
     done
-    echo ${rtnCd}
   )
 }
 
@@ -181,48 +178,52 @@ registerSovrin() {
     exit 1
   fi
     
-  echo -e "\nRegistering agent on ${ledger} using DID:${AGENT_PUBLIC_DID}, Verkey: ${AGENT_VERKEY}..."
-  REGISTER_DID_RESULT=$(${CURL_EXE} \
+  echo -e "Registering agent on ${ledger} using DID:${AGENT_PUBLIC_DID}, Verkey: ${AGENT_VERKEY}...\n"
+
+  # We need to pre-create the curl command, otherwise the execution could fail
+  regCmd=$(echo "${CURL_EXE} \
       -s \
       -X POST \
-      -H "Content-Type: application/json charset=utf-8" \
-      -d "{\"network\":\"${ledger}\",\"did\":\"${did}\",\"verkey\":\"${verkey}\",\"paymentaddr\":\"\"}" \
-      "https://selfserve.sovrin.org/nym")
+      -H \"Content-Type: application/json charset=utf-8\" \
+      -d \"{\\\"network\\\":\\\"${ledger}\\\",\\\"did\\\":\\\"${did}\\\",\\\"verkey\\\":\\\"${verkey}\\\",\\\"paymentaddr\\\":\\\"\\\"}\" \
+      \"https://selfserve.sovrin.org/nym\"")
+  REGISTER_DID_RESULT=$(eval ${regCmd})
 
   if [[ ! "200" == $(echo $REGISTER_DID_RESULT | ${JQ_EXE} -r '.statusCode') ]]; then
     echoRed "The agent registration failed with the following message: ${REGISTER_DID_RESULT}"
     docker-compose stop
     rm ".env"
-    return 1
+    exit 1
   fi
 }
 
 generateTaaPayload() {
-  TAA=$(${CURL_EXE} \
+  ${CURL_EXE} \
+      -s \
       -X GET \
       -H "X-Api-Key:${AGENT_ADMIN_API_KEY}" \
-      "http://localhost:${AGENT_ADMIN_PORT}/ledger/taa")
-  TAA_TEXT=$(echo $TAA | ${JQ_EXE} '.result.taa_record.text')
-  # TAA_TEXT=$(echo "${TAA_TEXT}" | iconv -t utf-8 | sed 's/"/\\\"/g')
-  TAA_VERSION=$(echo $TAA | ${JQ_EXE} '.result.taa_record.version')
-  echo "{\"mechanism\":\"${SELECTED_MECHANISM}\", \"version\": \"${TAA_VERSION}\", \"text\":\"${TAA_TEXT}\"}" > taa_payload.json
+      "http://localhost:${AGENT_ADMIN_PORT}/ledger/taa" \
+  | ${JQ_EXE} '{ "mechanism":"at_submission", "version": "\(.result.taa_record.version)", "text": "\(.result.taa_record.text)" }' \
+  > taa_payload.json
 }
 
 acceptTAA() {
   generateTaaPayload
 
-  TAA_ACCEPT_REAULT=$(${CURL_EXE} \
+  TAA_ACCEPT_RESULT=$(${CURL_EXE} \
+      -s \
       -X POST \
       -H "X-Api-Key:${AGENT_ADMIN_API_KEY}" \
       -H "Content-Type: application/json charset=utf-8" \
       -d @taa_payload.json \
       "http://localhost:${AGENT_ADMIN_PORT}/ledger/taa/accept")
-  
-  if [[ ${TAA_ACCEPT_REAULT} == "{}" ]]; then
-    echo "TAA accepted successfully"
+
+  if [[ "${TAA_ACCEPT_RESULT}" == "{}" ]]; then
+    echo -e "TAA accepted successfully \n"
     rm ./taa_payload.json
   else
-    echoRed "Failed to accept TAA"
+    echoRed "Failed to accept TAA: ${TAA_ACCEPT_RESULT}"
+    exit 1
   fi
 }
 
@@ -231,7 +232,7 @@ provisionAgent(){
     echo "Generated AGENT_WALLET_SEED=${AGENT_WALLET_SEED}"
     echo "AGENT_WALLET_SEED=${AGENT_WALLET_SEED}" > .env
 
-    echo "Starting agent in read-only mode...\n"
+    echo -e "\nStarting agent in read-only mode...\n"
     export AGENT_READ_ONLY_MODE="true"
     configureEnvironment "$@"
     docker-compose --env-file .env up -d wallet agent
@@ -239,9 +240,9 @@ provisionAgent(){
     echo
     waitForAgent ${AGENT_ADMIN_PORT}
 
-    echo
-    echo "Retrieving agent configuration..."
+    echo -e "\nRetrieving agent configuration..."
     AGENT_PUBLIC_INFO=$(${CURL_EXE} \
+                      -s \
                       -X GET \
                       -H  "accept: application/json" \
                       -H  "X-Api-Key: $AGENT_ADMIN_API_KEY"\
@@ -254,13 +255,12 @@ provisionAgent(){
     echo
     registerSovrin $AGENT_PUBLIC_DID $AGENT_VERKEY
 
-    echo
-    echo "Agent registered successfully, accepting TAA..."
+    echo -e "Agent registered successfully, accepting TAA...\n"
     acceptTAA
 
     unset AGENT_READ_ONLY_MODE
     echo
-    echo "Agent provisioning completed, ready for startup"    
+    echo -e "Agent provisioning completed, ready for startup\n"
 }
 
 build() {
@@ -475,7 +475,6 @@ case "${COMMAND}" in
     isCurlInstalled
 
     if [[ ! -f ".env" ]]; then
-      echo "First/clean start detected, provisioning agent on Sovrin StagingNet..." 
       provisionAgent
     fi
   ;;
@@ -483,18 +482,22 @@ case "${COMMAND}" in
     isJQInstalled
     isCurlInstalled
 
-    if [[ ! -f ".env" ]]; then
-      echo "First/clean start detected, provisioning agent on Sovrin StagingNet..." 
-      provisionAgent
-    fi
-
     if [ -z "$NGROK_AGENT_ENDPOINT" ]; then
       isNgrokInstalled
-      export NGROK_AGENT_ENDPOINT=$(${CURL_EXE} -X GET "http://localhost:4040/api/tunnels" | ${JQ_EXE} -r '.tunnels | map(select(.name | contains("issuer-agent"))) | .[0] | .public_url')
+      export NGROK_AGENT_ENDPOINT=$(${CURL_EXE} \
+            -s \
+            -X GET \
+            "http://localhost:4040/api/tunnels" \
+            | ${JQ_EXE} -r '.tunnels | map(select(.name | contains("issuer-agent"))) | .[0] | .public_url')
     fi
 
     checkNgrokTunnelActive
     echo "The agent endpoint is: ${NGROK_AGENT_ENDPOINT}"
+
+    if [[ ! -f ".env" ]]; then
+      echo "First/clean start detected, provisioning agent on Sovrin StagingNet..." 
+      provisionAgent
+    fi
 
     configureEnvironment "$@"
     # customizeKeycloakConfig
@@ -508,6 +511,9 @@ case "${COMMAND}" in
   rm|down)
     if [ -f ".env" ] ; then
         rm ".env"
+    fi
+    if [ -f "taa_payload.json" ] ; then
+        rm "taa_payload.json"
     fi
     configureEnvironment
     deleteVolumes

--- a/docker/manage
+++ b/docker/manage
@@ -6,14 +6,14 @@ set -e
 #
 # Global utility functions - START
 #
-function echoError (){
+function echoRed (){
   _msg=${1}
   _red='\e[31m'
   _nc='\e[0m' # No Color
   echo -e "${_red}${_msg}${_nc}"
 }
 
-function echoWarning (){
+function echoYellow (){
   _msg=${1}
   _yellow='\e[33m'
   _nc='\e[0m' # No Color
@@ -33,8 +33,8 @@ function isInstalled () {
 function isCurlInstalled () {
   CURL_EXE=curl
   if ! isInstalled ${CURL_EXE}; then
-    echoError "The ${CURL_EXE} executable is required and was not found on your path."
-    echoError "If your shell of choice doesn't come with curl preinstalled, try installing it using either [Homebrew](https://brew.sh/) (MAC) or [Chocolatey](https://chocolatey.org/) (Windows)."
+    echoRed "The ${CURL_EXE} executable is required and was not found on your path."
+    echoRed "If your shell of choice doesn't come with curl preinstalled, try installing it using either [Homebrew](https://brew.sh/) (MAC) or [Chocolatey](https://chocolatey.org/) (Windows)."
     exit 1
   fi
 }
@@ -42,9 +42,9 @@ function isCurlInstalled () {
 function isJQInstalled () {
   JQ_EXE=jq
   if ! isInstalled ${JQ_EXE}; then
-    echoError "The ${JQ_EXE} executable is required and was not found on your path."
-    echoError "Installation instructions can be found here: https://stedolan.github.io/jq/download"
-    echoError "Alternatively, a package manager such as Chocolatey (Windows) or Brew (Mac) can be used to install this dependecy."
+    echoRed "The ${JQ_EXE} executable is required and was not found on your path."
+    echoRed "Installation instructions can be found here: https://stedolan.github.io/jq/download"
+    echoRed "Alternatively, a package manager such as Chocolatey (Windows) or Brew (Mac) can be used to install this dependecy."
     exit 1
   fi
 }
@@ -52,17 +52,17 @@ function isJQInstalled () {
 function isNgrokInstalled () {
   NGROK_EXE=ngrok
   if ! isInstalled ${NGROK_EXE}; then
-    echoError "The ${NGROK_EXE} executable is needed and not on your path."
-    echoError "It can be downloaded from here: https://ngrok.com/download"
-    echoError "Alternatively, a package manager such as Chocolatey (Windows) or Brew (Mac) can be used to install this dependecy."
+    echoRed "The ${NGROK_EXE} executable is needed and not on your path."
+    echoRed "It can be downloaded from here: https://ngrok.com/download"
+    echoRed "Alternatively, a package manager such as Chocolatey (Windows) or Brew (Mac) can be used to install this dependecy."
     exit 1
   fi
 }
 
 function checkNgrokTunnelActive () {
   if [ -z "${NGROK_AGENT_ENDPOINT}" ]; then
-    echoError "It appears that ngrok tunneling is not enabled."
-    echoError "Please open another shell in the scripts folder and execute start-ngrok.sh before trying again."
+    echoRed "It appears that ngrok tunneling is not enabled."
+    echoRed "Please open another shell in the scripts folder and execute start-ngrok.sh before trying again."
     exit 1
   fi
 }
@@ -71,10 +71,10 @@ function customizeKeycloakConfig () {
   # Customize realm settings for development environment
   cp -f ./keycloak/config/realm-export.json ./keycloak/config/realm-export-docker.json
   if [ -z "$GITHUB_CLIENT_ID" ] || [ -z "$GITHUB_CLIENT_SECRET" ]; then
-    echoWarning "The client id and/or secret for the integration of GitHub as IDP for Keycloak were not provided."
-    echoWarning "Please set the GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET environment variables to use GitHub as your IDP."
-    echoWarning "To get your  client id/secret combination, please visit: https://github.com/settings/developers"
-    echoWarning "Press Ctrl+C now to stop, or wait to proceed without GitHub integration."
+    echoYellow "The client id and/or secret for the integration of GitHub as IDP for Keycloak were not provided."
+    echoYellow "Please set the GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET environment variables to use GitHub as your IDP."
+    echoYellow "To get your  client id/secret combination, please visit: https://github.com/settings/developers"
+    echoYellow "Press Ctrl+C now to stop, or wait to proceed without GitHub integration."
     sleep 8;
   else
     # Preparing Keycloak realm...
@@ -102,6 +102,7 @@ function generateSeed(){
     echo ${_seed}
   )
 }
+
 #
 # Global utility functions - END
 #
@@ -128,6 +129,9 @@ usage() {
       down - Brings down the services and removes the volumes (storage) and containers.
       rm - Same as down
 
+      provision - Only starts the agent and wallet, registers teh agent on Sovrin Staging Net and accepts the TAA.
+                  Automatically performed when start detects a first/clean run. 
+
 EOF
   exit 1
 }
@@ -135,6 +139,130 @@ EOF
 # -----------------------------------------------------------------------------------------------------------------
 # Functions:
 # -----------------------------------------------------------------------------------------------------------------
+pingAgent(){
+  port=${1}
+
+  # ping agent using a backchannel-exposed api
+  rtnCd=$(curl -s --write-out '%{http_code}' --output /dev/null http://localhost:${port}/api/doc)
+  if (( ${rtnCd} == 200 )); then
+    return 0
+  else
+    return 1
+  fi
+}
+
+waitForAgent(){
+  (
+    # Wait for agent to start ...
+    local startTime=${SECONDS}
+    rtnCd=0
+    printf "Waiting for agent to start"
+    while ! pingAgent ${@}; do
+      printf "."
+      local duration=$(($SECONDS - $startTime))
+      if (( ${duration} >= ${AGENT_TIMEOUT} )); then
+        echoRed "\nThe agent failed to start within ${duration} seconds.\n"
+        rtnCd=1
+        break
+      fi
+      sleep 1
+    done
+    echo ${rtnCd}
+  )
+}
+
+registerSovrin() {
+  did=${1}
+  verkey=${2}
+  ledger=${3:-"stagingnet"}
+  
+  if [ -z "${did}" ] || [ -z "${verkey}" ]|| [ -z "${ledger}" ]; then
+    echoRed "\nresgisterSovrin; You MUST specify the following parameters:\n- did\n- verkey"
+    exit 1
+  fi
+    
+  echo -e "\nRegistering agent on ${ledger} using DID:${AGENT_PUBLIC_DID}, Verkey: ${AGENT_VERKEY}..."
+  REGISTER_DID_RESULT=$(${CURL_EXE} \
+      -s \
+      -X POST \
+      -H "Content-Type: application/json charset=utf-8" \
+      -d "{\"network\":\"${ledger}\",\"did\":\"${did}\",\"verkey\":\"${verkey}\",\"paymentaddr\":\"\"}" \
+      "https://selfserve.sovrin.org/nym")
+
+  if [[ ! "200" == $(echo $REGISTER_DID_RESULT | ${JQ_EXE} -r '.statusCode') ]]; then
+    echoRed "The agent registration failed with the following message: ${REGISTER_DID_RESULT}"
+    docker-compose stop
+    rm ".env"
+    return 1
+  fi
+}
+
+generateTaaPayload() {
+  TAA=$(${CURL_EXE} \
+      -X GET \
+      -H "X-Api-Key:${AGENT_ADMIN_API_KEY}" \
+      "http://localhost:${AGENT_ADMIN_PORT}/ledger/taa")
+  TAA_TEXT=$(echo $TAA | ${JQ_EXE} '.result.taa_record.text')
+  # TAA_TEXT=$(echo "${TAA_TEXT}" | iconv -t utf-8 | sed 's/"/\\\"/g')
+  TAA_VERSION=$(echo $TAA | ${JQ_EXE} '.result.taa_record.version')
+  echo "{\"mechanism\":\"${SELECTED_MECHANISM}\", \"version\": \"${TAA_VERSION}\", \"text\":\"${TAA_TEXT}\"}" > taa_payload.json
+}
+
+acceptTAA() {
+  generateTaaPayload
+
+  TAA_ACCEPT_REAULT=$(${CURL_EXE} \
+      -X POST \
+      -H "X-Api-Key:${AGENT_ADMIN_API_KEY}" \
+      -H "Content-Type: application/json charset=utf-8" \
+      -d @taa_payload.json \
+      "http://localhost:${AGENT_ADMIN_PORT}/ledger/taa/accept")
+  
+  if [[ ${TAA_ACCEPT_REAULT} == "{}" ]]; then
+    echo "TAA accepted successfully"
+    rm ./taa_payload.json
+  else
+    echoRed "Failed to accept TAA"
+  fi
+}
+
+provisionAgent(){
+    AGENT_WALLET_SEED=$(generateSeed dts-vc-issuer-demo)
+    echo "Generated AGENT_WALLET_SEED=${AGENT_WALLET_SEED}"
+    echo "AGENT_WALLET_SEED=${AGENT_WALLET_SEED}" > .env
+
+    echo "Starting agent in read-only mode...\n"
+    export AGENT_READ_ONLY_MODE="true"
+    configureEnvironment "$@"
+    docker-compose --env-file .env up -d wallet agent
+    
+    echo
+    waitForAgent ${AGENT_ADMIN_PORT}
+
+    echo
+    echo "Retrieving agent configuration..."
+    AGENT_PUBLIC_INFO=$(${CURL_EXE} \
+                      -X GET \
+                      -H  "accept: application/json" \
+                      -H  "X-Api-Key: $AGENT_ADMIN_API_KEY"\
+                      "http://localhost:${AGENT_ADMIN_PORT}/wallet/did/public")
+    AGENT_PUBLIC_DID=$(echo $AGENT_PUBLIC_INFO | ${JQ_EXE} '.result.did')
+    AGENT_VERKEY=$(echo $AGENT_PUBLIC_INFO | ${JQ_EXE} '.result.verkey')
+    echo "AGENT_PUBLIC_DID=${AGENT_PUBLIC_DID}" >> .env
+    echo "AGENT_VERKEY=${AGENT_VERKEY}" >> .env
+
+    echo
+    registerSovrin $AGENT_PUBLIC_DID $AGENT_VERKEY
+
+    echo
+    echo "Agent registered successfully, accepting TAA..."
+    acceptTAA
+
+    unset AGENT_READ_ONLY_MODE
+    echo
+    echo "Agent provisioning completed, ready for startup"    
+}
+
 build() {
   echo -e "\nBuilding dts-vc-issuer-api development image..."
   docker build \
@@ -180,9 +308,10 @@ configureEnvironment() {
   # Global
   export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-"dts-vc-issuer"}"
   export DEBUG=${DEBUG}
-  export LOG_LEVEL=${LOG_LEVEL:-"DEBUG"}
-  export LEDGER_URL=${LEDGER_URL:-"http://test.bcovrin.vonx.io"}
+  export LOG_LEVEL=${LOG_LEVEL:-"WARN"}
+  export LEDGER_URL=${LEDGER_URL:-"https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis"}
   export TAILS_SERVER_URL=${TAILS_SERVER_URL:-"https://tails-dev.vonx.io"}
+  export AGENT_TIMEOUT=30
 
   # frontend
   export FRONTEND_WEB_PORT=4200
@@ -229,6 +358,7 @@ configureEnvironment() {
   if [ ! -z "${AGENT_ADMIN_API_KEY}" ]; then
     AGENT_ADMIN_MODE="admin-api-key ${AGENT_ADMIN_API_KEY}"
   fi
+  export AGENT_READ_ONLY_MODE=${AGENT_READ_ONLY_MODE:-"false"}
 
   # issuer api
   export ISSUER_DATABASE_NAME="dts_issuer_db"
@@ -306,7 +436,7 @@ toLower() {
   echo $(echo ${@} | tr '[:upper:]' '[:lower:]')
 }
 
-echoError (){
+echoRed (){
   _msg=${1}
   _red='\033[0;31m'
   _nc='\033[0m' # No Color
@@ -340,26 +470,34 @@ case "${COMMAND}" in
     configureEnvironment $@
     build ${_startupParams}
     ;;
+  provision)
+    isJQInstalled
+    isCurlInstalled
+
+    if [[ ! -f ".env" ]]; then
+      echo "First/clean start detected, provisioning agent on Sovrin StagingNet..." 
+      provisionAgent
+    fi
+  ;;
   start|start|up)
     isJQInstalled
     isCurlInstalled
 
     if [[ ! -f ".env" ]]; then
-      AGENT_WALLET_SEED=$(generateSeed dts-vc-issuer-demo)
-      echo "Generated AGENT_WALLET_SEED=${AGENT_WALLET_SEED}"
-      echo "AGENT_WALLET_SEED=${AGENT_WALLET_SEED}" > .env
+      echo "First/clean start detected, provisioning agent on Sovrin StagingNet..." 
+      provisionAgent
     fi
 
     if [ -z "$NGROK_AGENT_ENDPOINT" ]; then
       isNgrokInstalled
-      export NGROK_AGENT_ENDPOINT=$(${CURL_EXE} http://localhost:4040/api/tunnels | ${JQ_EXE} --raw-output '.tunnels | map(select(.name | contains("issuer-agent"))) | .[0] | .public_url')
+      export NGROK_AGENT_ENDPOINT=$(${CURL_EXE} -X GET "http://localhost:4040/api/tunnels" | ${JQ_EXE} -r '.tunnels | map(select(.name | contains("issuer-agent"))) | .[0] | .public_url')
     fi
 
     checkNgrokTunnelActive
     echo "The agent endpoint is: ${NGROK_AGENT_ENDPOINT}"
 
     configureEnvironment "$@"
-    customizeKeycloakConfig
+    # customizeKeycloakConfig
     docker-compose --env-file .env up -d ${_startupParams}
     docker-compose logs -f
     ;;

--- a/docker/manage
+++ b/docker/manage
@@ -129,7 +129,7 @@ usage() {
       down - Brings down the services and removes the volumes (storage) and containers.
       rm - Same as down
 
-      provision - Only starts the agent and wallet, registers teh agent on Sovrin Staging Net and accepts the TAA.
+      provision - Only starts the agent and wallet, registers the agent on Sovrin Staging Net and accepts the TAA.
                   Automatically performed when start detects a first/clean run. 
 
 EOF


### PR DESCRIPTION
The PR includes updates to the `manage` script that automate the provisioning of the agent to be performend on Sovrin StagingNet rather than BCovrin Test.

Following the same logic that was already in place, the new scripts will detect whether the agent is being started for the first time (by checking if an `.env` file is already present) and perform the following steps to provision a new agent:
- start agent and wallet, with the agent in read-only mode connected to Sovrin StagingNet
- pull the public DID and verkey from the agent, and use them to register as endorser on StagingNet
- accept the TAA

At this point, if the user has executed `./manage start` the agent will be restarted in write mode alongside all of the remaining services. The provisioning steps are only performed once on the first/clean start.

It is also possible to run `./manage provision` before executing `./manage start` to just start the agent in read only mode and register it on StagingNet and accept the TAA: this is useful, as an example, when starting for the first time using an agent that has previously been connected to BCovrin Test.

Alternatively, when migrating from an agent previously regsitered on BCovrin Test you can start from scratch by first executing `./manage rm`.